### PR TITLE
Fix/nomad leak

### DIFF
--- a/src/CoolFileSystem.cpp
+++ b/src/CoolFileSystem.cpp
@@ -733,7 +733,7 @@ int CoolFileSystem::isDataSaved() {
 *  lines left
 */
 String *CoolFileSystem::getSensorSavedData(int &lines) {
-  int maxString = 5;
+  int maxString = 2;
   String *sensorsDataArray = new String[maxString];
   lines = 0;
 

--- a/src/CoolFileSystem.cpp
+++ b/src/CoolFileSystem.cpp
@@ -733,7 +733,7 @@ int CoolFileSystem::isDataSaved() {
 *  lines left
 */
 String *CoolFileSystem::getSensorSavedData(int &lines) {
-  int maxString = 2;
+  int maxString = 1;
   String *sensorsDataArray = new String[maxString];
   lines = 0;
 

--- a/src/CoolFileSystem.cpp
+++ b/src/CoolFileSystem.cpp
@@ -733,7 +733,7 @@ int CoolFileSystem::isDataSaved() {
 *  lines left
 */
 String *CoolFileSystem::getSensorSavedData(int &lines) {
-  int maxString = 50;
+  int maxString = 5;
   String *sensorsDataArray = new String[maxString];
   lines = 0;
 


### PR DESCRIPTION
reducing the lines of saved messages sent when we are online from 50 to 2 messages. this prevents overflowing memory since we don't know the length of the String. This is certainly not a "perfect" solution but reduces drastically the amount of lost messages. since the ESP don't crash anymore and IF EVER he crashes or the communication doesn't work we lose only 2 messages..
I could limit the size of the string but I think this is not a good Idea (loosing more messages) and anyway the problem is the datamanagement which is so bad that anyway everything must be rebuilt from zero IMHO. since we can't say: 2 was not sent but 3, 4 and 5 are OK we will permanently lose messages...
The only downside is that a weather station which was not online for 24h will take 12h to get all data to the server.