### PR TITLE
Enhancement/wall moisture

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ The COOL Board embedded software makes heavy use of the SPIFFS for storing its c
 * `uv`: set this to `true` if you want to measure ultraviolet index using the SI114X Sensor
 * `vbat`: set this to `true` if you want to measure battery voltage 
 * `soilMoisture`: set this to `true` if you want to activate the soil moisture sensor	
+* `wallMoisture`: set this to `true` if you want to use the moisture sensor for wall/wood moisture sensing. `soilMoisture` MUST be `false` in this case	
+
 	
 #### `externalSensorsConfig.json`
 

--- a/examples/WeatherStation/data/coolBoardSensorsConfig.json
+++ b/examples/WeatherStation/data/coolBoardSensorsConfig.json
@@ -10,5 +10,6 @@
     "uv": 1
   },
   "vbat": 1,
-  "soilMoisture": 1
+  "soilMoisture": 1,
+  "wallMoisture": 0
 }

--- a/src/extras/CoolBoardSensors.cpp
+++ b/src/extras/CoolBoardSensors.cpp
@@ -344,18 +344,13 @@ float CoolBoardSensors::readMoisture() {
 float CoolBoardSensors::readWallMoisture() {
     float val = 0;
     digitalWrite(AnMplex, HIGH); // enable analog Switch to get the moisture
-  
     delay(200);
     for (int i = 0; i<=63; i++)
     {
       digitalWrite(EnMoisture, LOW); // enable moisture sensor and waith a bit
-  
       delay(2);
-  
       val = val + analogRead(A0); // read the value form the moisture sensor
-  
       delay(2);
-  
       digitalWrite(EnMoisture, HIGH); // disable moisture sensor for minimum wear
     }
     val = val / 64;

--- a/src/extras/CoolBoardSensors.cpp
+++ b/src/extras/CoolBoardSensors.cpp
@@ -166,6 +166,9 @@ String CoolBoardSensors::read() {
   if (soilMoistureActive) {
     root["soilMoisture"] = this->readMoisture();
   }
+  if (wallMoistureActive) {
+    root["wallMoisture"] = this->readWallMoisture();
+  }
   root.printTo(data);
   DEBUG_JSON("Onboard sensors values JSON:", root);
   return (data);
@@ -232,6 +235,10 @@ bool CoolBoardSensors::config() {
         this->soilMoistureActive = json["soilMoisture"];
       }
       json["soilMoisture"] = this->soilMoistureActive;
+      if (json["wallMoisture"].success()) {
+        this->wallMoistureActive = json["wallMoisture"];
+      }
+      json["wallMoisture"] = this->wallMoistureActive;
       coolBoardSensorsConfig.close();
       coolBoardSensorsConfig = SPIFFS.open("/coolBoardSensorsConfig.json", "w");
       if (!coolBoardSensorsConfig) {
@@ -260,6 +267,7 @@ void CoolBoardSensors::printConf() {
   INFO_VAR("  Light UV             =", lightDataActive.uv);
   INFO_VAR("  Battery voltage      =", vbatActive);
   INFO_VAR("  Soil moisture        =", soilMoistureActive);
+  INFO_VAR("  Wall moisture        =", wallMoistureActive);
 }
 
 /**
@@ -332,3 +340,25 @@ float CoolBoardSensors::readMoisture() {
   DEBUG_VAR("Computed soil moisture:", result);
   return (result);
 }
+
+float CoolBoardSensors::readWallMoisture() {
+    float val = 0;
+    digitalWrite(AnMplex, HIGH); // enable analog Switch to get the moisture
+  
+    delay(200);
+    for (int i = 0; i<=63; i++)
+    {
+      digitalWrite(EnMoisture, LOW); // enable moisture sensor and waith a bit
+  
+      delay(2);
+  
+      val = val + analogRead(A0); // read the value form the moisture sensor
+  
+      delay(2);
+  
+      digitalWrite(EnMoisture, HIGH); // disable moisture sensor for minimum wear
+    }
+    val = val / 64;
+    DEBUG_VAR("Raw wall moisture sensor value:", val);
+    return (float(val));//result);
+  }

--- a/src/extras/CoolBoardSensors.cpp
+++ b/src/extras/CoolBoardSensors.cpp
@@ -164,7 +164,7 @@ String CoolBoardSensors::read() {
     root["Vbat"] = this->readVBat();
   }
   if (soilMoistureActive) {
-    root["soilMoisture"] = this->readMoisture();
+    root["soilMoisture"] = this->readSoilMoisture();
   }
   if (wallMoistureActive) {
     root["wallMoisture"] = this->readWallMoisture();
@@ -315,14 +315,14 @@ float CoolBoardSensors::readVBat() {
 }
 
 /**
- *  CoolBoardSensors::readMoisture():
+ *  CoolBoardSensors::readSoilMoisture():
  *  This method is provided to red the
  *  Soil Moisture
  *
  *  \return a float represnting the
  *  soil moisture
  */
-float CoolBoardSensors::readMoisture() {
+float CoolBoardSensors::readSoilMoisture() {
   digitalWrite(EnMoisture, LOW); // enable moisture sensor and wait a bit
   digitalWrite(AnMplex, HIGH);   // enable analog switch to read moisture value
   delay(2000);
@@ -345,8 +345,7 @@ float CoolBoardSensors::readWallMoisture() {
     float val = 0;
     digitalWrite(AnMplex, HIGH); // enable analog Switch to get the moisture
     delay(200);
-    for (int i = 0; i<=63; i++)
-    {
+    for (int i = 0; i<=63; i++){
       digitalWrite(EnMoisture, LOW); // enable moisture sensor and waith a bit
       delay(2);
       val = val + analogRead(A0); // read the value form the moisture sensor
@@ -355,5 +354,5 @@ float CoolBoardSensors::readWallMoisture() {
     }
     val = val / 64;
     DEBUG_VAR("Raw wall moisture sensor value:", val);
-    return (float(val));//result);
+    return (float(val));
   }

--- a/src/extras/CoolBoardSensors.cpp
+++ b/src/extras/CoolBoardSensors.cpp
@@ -345,14 +345,14 @@ float CoolBoardSensors::readWallMoisture() {
     float val = 0;
     digitalWrite(AnMplex, HIGH); // enable analog Switch to get the moisture
     delay(200);
-    for (int i = 0; i<=63; i++){
+    for (int i = 1; i<=64; i++){     //oversample value 64 times for stable readings
       digitalWrite(EnMoisture, LOW); // enable moisture sensor and waith a bit
       delay(2);
       val = val + analogRead(A0); // read the value form the moisture sensor
       delay(2);
       digitalWrite(EnMoisture, HIGH); // disable moisture sensor for minimum wear
     }
-    val = val / 64;
+    val = val / 64; //divide by 64 to get the average
     DEBUG_VAR("Raw wall moisture sensor value:", val);
     return (float(val));
   }

--- a/src/extras/CoolBoardSensors.h
+++ b/src/extras/CoolBoardSensors.h
@@ -63,6 +63,8 @@ public:
 
   float readMoisture();
 
+  float readWallMoisture();
+
   CoolSI114X lightSensor;
   BME280 envSensor;
 
@@ -111,7 +113,12 @@ private:
   /**
    *  set soilMoistureActive to 1 to have soil Moisture readings
    */
-  bool soilMoistureActive = 1;
+  bool soilMoistureActive = 1; 
+  
+  /**
+  *  set wallMoistureActive to 1 to have soil Moisture readings
+  */
+  bool wallMoistureActive = 0;
 };
 
 #endif

--- a/src/extras/CoolBoardSensors.h
+++ b/src/extras/CoolBoardSensors.h
@@ -61,7 +61,7 @@ public:
 
   float readVBat();
 
-  float readMoisture();
+  float readSoilMoisture();
 
   float readWallMoisture();
 


### PR DESCRIPTION
Adds the possibility to measure wall or wood humidity with a slightly modified coolboard.
Things to add in the coolBoardSensorConfig.json to get this working:
`"soilMoisture": 0,
  "wallMoisture": 1`

the complete config should look like this :
`{
  "BME280": {
    "temperature": 1,
    "humidity": 1,
    "pressure": 1
  },
  "SI114X": {
    "visible": 1,
    "ir": 1,
    "uv": 1
  },
  "vbat": 1,
  "soilMoisture": 0,
  "wallMoisture": 1
}`
