### PR TITLE
Configurations sent over MQTT are not saved

### DIFF
--- a/src/core/CoolBoard.cpp
+++ b/src/core/CoolBoard.cpp
@@ -643,9 +643,6 @@ void CoolBoard::update(const char *answer) {
           onBoardActor.write(kv.value.as<bool>());
         }
       }
-    } else {
-      // restart La COOL Board to apply the new configuration
-      ESP.restart();
     }
 
     // Irene calibration through update message


### PR DESCRIPTION
By sending a configuration over MQTT I saw a bug in Coolboard::update()
The if/else (line 620 & 646) condition was just shooting the restart if `manual` is false (which happens..). this way not only the message is lost, it creates a infinite loop because the answer to the desired state was never sent. So the board get's the message over and over again without answering because it was rebooted to soon...