### PR TITLE
Fix/long logs

### DIFF
--- a/src/core/CoolBoard.cpp
+++ b/src/core/CoolBoard.cpp
@@ -438,7 +438,7 @@ void CoolBoard::readBoardData(JsonObject &reported) {
 void CoolBoard::sleep(unsigned long interval) {
   if (interval > 0) {
     INFO_VAR("Going to sleep for seconds:", interval);
-    ESP.deepSleep((interval * 1000 * 1000), WAKE_RF_DEFAULT);
+    ESP.deepSleep(uint64 (interval * 1000000), WAKE_RF_DEFAULT);
   }
 }
 

--- a/src/core/CoolBoard.cpp
+++ b/src/core/CoolBoard.cpp
@@ -438,7 +438,7 @@ void CoolBoard::readBoardData(JsonObject &reported) {
 void CoolBoard::sleep(unsigned long interval) {
   if (interval > 0) {
     INFO_VAR("Going to sleep for seconds:", interval);
-    ESP.deepSleep(uint64 (interval * 1000000), WAKE_RF_DEFAULT);
+    ESP.deepSleep((uint64(interval) * 1000000ULL), WAKE_RF_DEFAULT);
   }
 }
 


### PR DESCRIPTION
quickfix for the issue here : https://github.com/LaCoolCo/LaCOOLBoard/issues/55
printing a uint64 is quite a mess with arduino core but now I can have longer log delays without problem. I tried 2 and 4 hours successfully.
I still have to find and document the maximum value for the logInterval but IMO it is 4 294 967 295 seconds. please comment...