### PR TITLE
Fix Ram space when we reconnect to mqtts

### DIFF
--- a/src/core/CoolBoard.cpp
+++ b/src/core/CoolBoard.cpp
@@ -94,6 +94,7 @@ void CoolBoard::loop() {
     this->spiffsProblem();
   }
   if (!this->isConnected()) {
+    this->mqttClient->disconnect();
     INFO_LOG("Connecting...");
     this->connect();
   }


### PR DESCRIPTION
This is a fix to clean ram if we miss the wifi connection because the element with the credentials of mqtts they stay on memory, and when we repass to "mqttsConfig" whe charge the buffer on strings with the credentials from the binaries files. 
the reason of this fix is for situation when we have some externals sensors running on deepSleepMode = false.