### PR TITLE
Added Human readable date on logs messages

### DIFF
--- a/src/core/CoolLog.h
+++ b/src/core/CoolLog.h
@@ -45,7 +45,7 @@
 #define ADD_TIMESTAMP                                                          \
   do {                                                                         \
     Serial.print(F("["));                                                      \
-    Serial.print(CoolTime::getInstance().getIso8601DateTime());                \
+    Serial.print(CoolTime::getInstance().getHumanDateTime());                \
     Serial.print(F("]"));                                                      \
   } while (0)
 #else

--- a/src/core/CoolTime.cpp
+++ b/src/core/CoolTime.cpp
@@ -85,3 +85,10 @@ String CoolTime::getIso8601DateTime() {
   strftime(iso8601Date, sizeof iso8601Date, "%FT%TZ", gmtime(&t));
   return String(iso8601Date);
 }
+
+String CoolTime::getHumanDateTime() {
+  char humanDate[] = "YYYY-MM-DD HH:MM:SS";
+  time_t t = this->rtc.getTimestamp();
+  strftime(humanDate, sizeof humanDate, "%F %T ", gmtime(&t));
+  return String(humanDate);
+}

--- a/src/core/CoolTime.h
+++ b/src/core/CoolTime.h
@@ -44,6 +44,7 @@ public:
   void setDateTime(int year, int month, int day, int hour, int minutes,
                    int seconds);
   String getIso8601DateTime();
+  String getHumanDateTime();
   DS1337 rtc;
   static bool ntpSync;
 


### PR DESCRIPTION
Is a pull request to replace the iso8601 timestamp on CoolLog.h to one more 'human' Readable 
from:
```
[2018-07-02T15:26:58Z]
```
to
```
[2018-07-02 15:26:58]
```