### PR TITLE
Changes in sleep fonction for a higher loginterval

### DIFF
--- a/src/core/CoolBoard.h
+++ b/src/core/CoolBoard.h
@@ -46,6 +46,7 @@
 #define LOW_POWER_SLEEP 300
 #define MQTT_RETRIES 5
 #define MAX_MQTT_RETRIES 15
+#define MAX_SLEEP_TIME 3600
 
 class CoolBoard {
 
@@ -58,7 +59,7 @@ public:
   bool isConnected();
   unsigned long getLogInterval();
   void printConf();
-  void sleep(unsigned long interval);
+  void sleep();
   void handleActuators(JsonObject &reported);
   void readSensors(JsonObject &reported);
   void readBoardData(JsonObject &reported);


### PR DESCRIPTION
We wrote a `delay` of 5 seconds in order to know if the COOLBoard's switch is in LOAD position. It will allow the user to reset the board and to clean the EEPROM from the latest `Loginterval` known. Then he will have to put it back in RUN's position.