### PR TITLE
DFrobot EC kit on free IRN3000 input

### DIFF
--- a/examples/DFrobotEC/DFrobotEC.ino
+++ b/examples/DFrobotEC/DFrobotEC.ino
@@ -1,0 +1,27 @@
+/**
+ *	CoolBoardExample
+ *
+ *	This example shows typical use
+ *	of the CoolBoard with IRN3000 Ph/Temp interface 
+ *  and the DFrobot EC kit. connect the EC kit to 
+ *  ADC2 on IRN3000 and you should be ready to go.
+ *  Don't forget to power the device from IRN3000.
+ *
+ *	Save this example in another location
+ *	in order to safely modify the configuration files
+ *	in the data folder.
+ *
+ */
+
+#include <CoolBoard.h>
+
+CoolBoard coolBoard;
+
+void setup() {
+  Serial.begin(115200);
+  coolBoard.begin();
+}
+
+void loop() {
+  coolBoard.loop();
+}

--- a/examples/DFrobotEC/data/coolBoardActorConfig.json
+++ b/examples/DFrobotEC/data/coolBoardActorConfig.json
@@ -1,0 +1,21 @@
+{
+  "actif": false,
+  "inverted": false,
+  "temporal": false,
+  "low": [
+    0,
+    5000,
+    0,
+    0
+  ],
+  "high": [
+    0,
+    5000,
+    0,
+    0
+  ],
+  "type": [
+    "Temperature",
+    ""
+  ]
+}

--- a/examples/DFrobotEC/data/coolBoardConfig.json
+++ b/examples/DFrobotEC/data/coolBoardConfig.json
@@ -1,0 +1,9 @@
+{
+  "logInterval": 3600,
+  "ireneActive": true,
+  "jetpackActive": false,
+  "externalSensorsActive": false,
+  "sleepActive": true,
+  "manual": false,
+  "mqttServer": "mqtts.lacoolboard.io"
+}

--- a/examples/DFrobotEC/data/coolBoardLedConfig.json
+++ b/examples/DFrobotEC/data/coolBoardLedConfig.json
@@ -1,0 +1,3 @@
+{
+  "ledActive": true
+}

--- a/examples/DFrobotEC/data/coolBoardSensorsConfig.json
+++ b/examples/DFrobotEC/data/coolBoardSensorsConfig.json
@@ -1,0 +1,15 @@
+{
+  "BME280": {
+    "temperature": true,
+    "humidity": true,
+    "pressure": true
+  },
+  "SI114X": {
+    "visible": true,
+    "ir": true,
+    "uv": true
+  },
+  "vbat": true,
+  "soilMoisture": true,
+  "wallMoisture": false
+}

--- a/examples/DFrobotEC/data/externalSensorsConfig.json
+++ b/examples/DFrobotEC/data/externalSensorsConfig.json
@@ -1,0 +1,3 @@
+{
+  "sensorsNumber": 0
+}

--- a/examples/DFrobotEC/data/irene3000Config.json
+++ b/examples/DFrobotEC/data/irene3000Config.json
@@ -1,0 +1,13 @@
+{
+  "waterTemp": {
+    "active": true
+  },
+  "phProbe": {
+    "active": true
+  },
+  "adc2": {
+    "active": true,
+    "gain": 1,
+    "type": "DFrobotEC"
+  }
+}

--- a/examples/DFrobotEC/data/jetPackConfig.json
+++ b/examples/DFrobotEC/data/jetPackConfig.json
@@ -1,0 +1,170 @@
+{
+  "Act0": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      20,
+      0,
+      0,
+      0
+    ],
+    "high": [
+      30,
+      0,
+      0,
+      0
+    ],
+    "type": [
+      "Temperature",
+      ""
+    ]
+  },
+  "Act1": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      20,
+      0,
+      0,
+      0
+    ],
+    "high": [
+      30,
+      0,
+      0,
+      0
+    ],
+    "type": [
+      "Temperature",
+      ""
+    ]
+  },
+  "Act2": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      0,
+      3000,
+      0,
+      0
+    ],
+    "high": [
+      0,
+      5000,
+      0,
+      0
+    ],
+    "type": [
+      "",
+      ""
+    ]
+  },
+  "Act3": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      20,
+      3000,
+      0,
+      0
+    ],
+    "high": [
+      40,
+      5000,
+      0,
+      0
+    ],
+    "type": [
+      "Temperature",
+      ""
+    ]
+  },
+  "Act4": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      0,
+      0,
+      9,
+      0
+    ],
+    "high": [
+      0,
+      0,
+      7,
+      0
+    ],
+    "type": [
+      "",
+      "hour"
+    ]
+  },
+  "Act5": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      20,
+      0,
+      9,
+      0
+    ],
+    "high": [
+      40,
+      0,
+      7,
+      0
+    ],
+    "type": [
+      "Temperature",
+      "hour"
+    ]
+  },
+  "Act6": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      0,
+      0,
+      0,
+      50
+    ],
+    "high": [
+      0,
+      0,
+      0,
+      1
+    ],
+    "type": [
+      "",
+      "minute"
+    ]
+  },
+  "Act7": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      20,
+      0,
+      0,
+      50
+    ],
+    "high": [
+      40,
+      0,
+      0,
+      1
+    ],
+    "type": [
+      "Temperature",
+      "minute"
+    ]
+  }
+}

--- a/examples/DFrobotEC/data/wifiConfig.json
+++ b/examples/DFrobotEC/data/wifiConfig.json
@@ -1,0 +1,4 @@
+{
+  "wifiCount": 0,
+  "timeOut": 180
+}

--- a/src/core/Irene3000.cpp
+++ b/src/core/Irene3000.cpp
@@ -93,7 +93,11 @@ void Irene3000::read(JsonObject &root) {
     }
   }
   if (adc2.active) {
+    if (this->adc2.type == "DFrobotEC") {
+      readEC(root);
+    } else {
     root[adc2.type] = this->readADSChannel2();
+    }
   }
   DEBUG_JSON("Irene data:", root);
 }
@@ -202,6 +206,46 @@ void Irene3000::readTemp(JsonObject &root) {
     } else
       root["waterTemp"] = T;
   }
+}
+
+float Irene3000::readTemp() {
+  const double A = 3.9083E-3;
+  const double B = -5.775E-7;
+  double T;
+
+  this->ads.setGain(GAIN_EIGHT);
+
+  double adc0 = ads.readADC_SingleEnded(TEMP_CHANNEL);
+  double R = ((adc0 * V_GAIN_8) / 0.095) / 1000;
+
+  T = 0.0 - A;
+  T += sqrt((A * A) - 4.0 * B * (1.0 - R));
+  T /= (2.0 * B);
+  DEBUG_VAR("IRN3000 temperature in °C:", T);
+  return T ;
+}
+
+void Irene3000::readEC(JsonObject &root) {
+  int overSample = 16;
+  float ecCurrent = 0;
+  unsigned long average = 0;
+  unsigned int averageVoltage = 0;
+  for (int i = 0; i<=64; i++) {
+    delay(20);
+    average += readADSChannel2();
+  }
+  average = average / 64;
+  averageVoltage = average * 0.1875;
+  DEBUG_VAR("Average RAW : ", average);
+  DEBUG_VAR("Average Voltage : ", averageVoltage);
+  float TempCoefficient=1.0+0.0185*(readTemp()-25.0);    //temperature compensation formula: fFinalResult(25^C) = fFinalResult(current)/(1.0+0.0185*(fTP-25.0));
+  float CoefficientVolatge=(float)averageVoltage/TempCoefficient;   
+  if(CoefficientVolatge<=448)ecCurrent=6.84*CoefficientVolatge-64.32;   //1ms/cm<EC<=3ms/cm
+  else if(CoefficientVolatge<=1457)ecCurrent=6.98*CoefficientVolatge-127;  //3ms/cm<EC<=10ms/cm
+  else ecCurrent=5.3*CoefficientVolatge+2278;                           //10ms/cm<EC<20ms/cm
+  ecCurrent/=1000;    //convert us/cm to ms/cm
+  DEBUG_VAR("EC value",ecCurrent);
+  root["EC"] = ecCurrent;
 }
 
 void Irene3000::calibratepH7() {

--- a/src/core/Irene3000.cpp
+++ b/src/core/Irene3000.cpp
@@ -230,20 +230,27 @@ void Irene3000::readEC(JsonObject &root) {
   float ecCurrent = 0;
   unsigned long average = 0;
   unsigned int averageVoltage = 0;
+  //Oversample 64 time to get a good reading
   for (int i = 0; i<=64; i++) {
     delay(20);
     average += readADSChannel2();
   }
   average = average / 64;
+  // resolution for ADS1115 is 0.1875 uV per tick
   averageVoltage = average * 0.1875;
   DEBUG_VAR("Average RAW : ", average);
   DEBUG_VAR("Average Voltage : ", averageVoltage);
-  float TempCoefficient=1.0+0.0185*(readTemp()-25.0);    //temperature compensation formula: fFinalResult(25^C) = fFinalResult(current)/(1.0+0.0185*(fTP-25.0));
+  //temperature compensation formula: fFinalResult(25^C) = fFinalResult(current)/(1.0+0.0185*(fTP-25.0));
+  float TempCoefficient=1.0+0.0185*(readTemp()-25.0);
   float CoefficientVolatge=(float)averageVoltage/TempCoefficient;   
-  if(CoefficientVolatge<=448)ecCurrent=6.84*CoefficientVolatge-64.32;   //1ms/cm<EC<=3ms/cm
-  else if(CoefficientVolatge<=1457)ecCurrent=6.98*CoefficientVolatge-127;  //3ms/cm<EC<=10ms/cm
-  else ecCurrent=5.3*CoefficientVolatge+2278;                           //10ms/cm<EC<20ms/cm
-  ecCurrent/=1000;    //convert us/cm to ms/cm
+  //1ms/cm<EC<=3ms/cm
+  if(CoefficientVolatge<=448)ecCurrent=6.84*CoefficientVolatge-64.32;   
+  //3ms/cm<EC<=10ms/cm
+  else if(CoefficientVolatge<=1457)ecCurrent=6.98*CoefficientVolatge-127;  
+  //10ms/cm<EC<20ms/cm
+  else ecCurrent=5.3*CoefficientVolatge+2278;
+  //convert us/cm to ms/cm
+  ecCurrent/=1000;    
   DEBUG_VAR("EC value",ecCurrent);
   root["EC"] = ecCurrent;
 }

--- a/src/core/Irene3000.h
+++ b/src/core/Irene3000.h
@@ -55,6 +55,8 @@ public:
   int readADSChannel2();
   void readPh(JsonObject &root);
   void readTemp(JsonObject &root);
+  void readEC(JsonObject &root);
+  float readTemp();
   void resetParams();
   void calibratepH7();
   void calibratepH4();


### PR DESCRIPTION
this PR permits du use the rather cheap DFrobot EC kit on the unused ADC2 input on IRN3000.
The configuration file for IRN3000 should look like this : 
`{
  "waterTemp": {
    "active": true
  },
  "phProbe": {
    "active": true
  },
  "adc2": {
    "active": true,
    "gain": 1,
    "type": "DFrobotEC"
  }
}
`
This worked out of the box and values are good without calibration.