### PR TITLE
Integrating ERE 4 channel 4-20mA interface in API

### DIFF
--- a/examples/MCP3424_4-20mA/MCP3424_4-20mA.ino
+++ b/examples/MCP3424_4-20mA/MCP3424_4-20mA.ino
@@ -1,0 +1,24 @@
+/**
+ *	CoolBoardExample
+ *
+ *	This example shows typical use
+ *	of the CoolBoard.
+ *
+ *	Save this example in another location
+ *	in order to safely modify the configuration files
+ *	in the data folder.
+ *
+ */
+
+#include <CoolBoard.h>
+
+CoolBoard coolBoard;
+
+void setup() {
+  Serial.begin(115200);
+  coolBoard.begin();
+}
+
+void loop() {
+  coolBoard.loop();
+}

--- a/examples/MCP3424_4-20mA/data/coolBoardActorConfig.json
+++ b/examples/MCP3424_4-20mA/data/coolBoardActorConfig.json
@@ -1,0 +1,21 @@
+{
+  "actif": false,
+  "inverted": false,
+  "temporal": false,
+  "low": [
+    0,
+    5000,
+    0,
+    0
+  ],
+  "high": [
+    0,
+    5000,
+    0,
+    0
+  ],
+  "type": [
+    "Temperature",
+    ""
+  ]
+}

--- a/examples/MCP3424_4-20mA/data/coolBoardConfig.json
+++ b/examples/MCP3424_4-20mA/data/coolBoardConfig.json
@@ -1,0 +1,9 @@
+{
+  "logInterval": 3600,
+  "ireneActive": false,
+  "jetpackActive": false,
+  "externalSensorsActive": true,
+  "sleepActive": true,
+  "manual": false,
+  "mqttServer": "mqtts.lacoolboard.io"
+}

--- a/examples/MCP3424_4-20mA/data/coolBoardLedConfig.json
+++ b/examples/MCP3424_4-20mA/data/coolBoardLedConfig.json
@@ -1,0 +1,3 @@
+{
+  "ledActive": true
+}

--- a/examples/MCP3424_4-20mA/data/coolBoardSensorsConfig.json
+++ b/examples/MCP3424_4-20mA/data/coolBoardSensorsConfig.json
@@ -1,0 +1,15 @@
+{
+  "BME280": {
+    "temperature": true,
+    "humidity": true,
+    "pressure": true
+  },
+  "SI114X": {
+    "visible": true,
+    "ir": true,
+    "uv": true
+  },
+  "vbat": true,
+  "soilMoisture": true,
+  "wallMoisture": false
+}

--- a/examples/MCP3424_4-20mA/data/externalSensorsConfig.json
+++ b/examples/MCP3424_4-20mA/data/externalSensorsConfig.json
@@ -1,0 +1,13 @@
+{
+  "sensorsNumber": 1,
+  "sensor0":
+  {
+    "reference":"MCP342X_4-20mA",
+    "type":"Ticks",
+    "address":106,
+	  "kind0":"no1",
+	  "kind1":"no2",
+	  "kind2":"no3",
+	  "kind3":"no4"
+  }
+}

--- a/examples/MCP3424_4-20mA/data/irene3000Config.json
+++ b/examples/MCP3424_4-20mA/data/irene3000Config.json
@@ -1,0 +1,13 @@
+{
+  "waterTemp": {
+    "active": true
+  },
+  "phProbe": {
+    "active": true
+  },
+  "adc2": {
+    "active": true,
+    "gain": 0.67,
+    "type": "waterLevel"
+  }
+}

--- a/examples/MCP3424_4-20mA/data/jetPackConfig.json
+++ b/examples/MCP3424_4-20mA/data/jetPackConfig.json
@@ -1,0 +1,170 @@
+{
+  "Act0": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      20,
+      0,
+      0,
+      0
+    ],
+    "high": [
+      30,
+      0,
+      0,
+      0
+    ],
+    "type": [
+      "Temperature",
+      ""
+    ]
+  },
+  "Act1": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      20,
+      0,
+      0,
+      0
+    ],
+    "high": [
+      30,
+      0,
+      0,
+      0
+    ],
+    "type": [
+      "Temperature",
+      ""
+    ]
+  },
+  "Act2": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      0,
+      3000,
+      0,
+      0
+    ],
+    "high": [
+      0,
+      5000,
+      0,
+      0
+    ],
+    "type": [
+      "",
+      ""
+    ]
+  },
+  "Act3": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      20,
+      3000,
+      0,
+      0
+    ],
+    "high": [
+      40,
+      5000,
+      0,
+      0
+    ],
+    "type": [
+      "Temperature",
+      ""
+    ]
+  },
+  "Act4": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      0,
+      0,
+      9,
+      0
+    ],
+    "high": [
+      0,
+      0,
+      7,
+      0
+    ],
+    "type": [
+      "",
+      "hour"
+    ]
+  },
+  "Act5": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      20,
+      0,
+      9,
+      0
+    ],
+    "high": [
+      40,
+      0,
+      7,
+      0
+    ],
+    "type": [
+      "Temperature",
+      "hour"
+    ]
+  },
+  "Act6": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      0,
+      0,
+      0,
+      50
+    ],
+    "high": [
+      0,
+      0,
+      0,
+      1
+    ],
+    "type": [
+      "",
+      "minute"
+    ]
+  },
+  "Act7": {
+    "actif": false,
+    "inverted": false,
+    "temporal": false,
+    "low": [
+      20,
+      0,
+      0,
+      50
+    ],
+    "high": [
+      40,
+      0,
+      0,
+      1
+    ],
+    "type": [
+      "Temperature",
+      "minute"
+    ]
+  }
+}

--- a/examples/MCP3424_4-20mA/data/wifiConfig.json
+++ b/examples/MCP3424_4-20mA/data/wifiConfig.json
@@ -1,0 +1,4 @@
+{
+  "wifiCount": 0,
+  "timeOut": 180
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,7 @@ lib_deps =
   OneWire@2.3.4
   https://github.com/cyberp/DS1337
   https://github.com/practicalarduino/SHT1x
+  https://github.com/uChip/MCP342X.git
 build_flags = !echo "-DCOOL_FW_VERSION="\'\"$(git describe --tags --always)\"\' "-Wl,-Tesp8266.flash.4m2m.ld -DVTABLES_IN_FLASH
   -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY"
 

--- a/src/core/ExternalSensor.h
+++ b/src/core/ExternalSensor.h
@@ -33,6 +33,7 @@
 #include "CoolSDS011.h"
 #include <Arduino.h>
 #include <DallasTemperature.h>
+#include <MCP342X.h>
 
 #include "CoolLog.h"
 
@@ -328,4 +329,54 @@ public:
 private:
   SDS011 sensor;
 };
+
+template <> class ExternalSensor<MCP342X> : public BaseExternalSensor {
+public:
+  ExternalSensor(uint8_t i2c_addr) { sensor = MCP342X(i2c_addr); }
+
+  virtual uint8_t begin() {
+    //sensor.testConnection();
+    Serial.println(sensor.testConnection() ? "MCP342X connection successful" : "MCP342X connection failed");
+    return (true);
+  }
+
+  virtual float read(int16_t *a, int16_t *b, int16_t *c, int16_t *d) {
+    sensor.configure( MCP342X_MODE_ONESHOT |
+      MCP342X_CHANNEL_1 |
+      MCP342X_SIZE_16BIT |
+      MCP342X_GAIN_2X
+    );
+    sensor.startConversion();
+    sensor.getResult(&*a);
+
+    sensor.configure( MCP342X_MODE_ONESHOT |
+      MCP342X_CHANNEL_2 |
+      MCP342X_SIZE_16BIT |
+      MCP342X_GAIN_2X
+    );
+    sensor.startConversion();
+    sensor.getResult(&*b);
+
+    sensor.configure( MCP342X_MODE_ONESHOT |
+      MCP342X_CHANNEL_3 |
+      MCP342X_SIZE_16BIT |
+      MCP342X_GAIN_2X
+    );
+    sensor.startConversion();
+    sensor.getResult(&*c);
+
+    sensor.configure( MCP342X_MODE_ONESHOT |
+      MCP342X_CHANNEL_4 |
+      MCP342X_SIZE_16BIT |
+      MCP342X_GAIN_2X
+    );
+    sensor.startConversion();
+    sensor.getResult(&*d);
+    return (0.0);
+  }
+
+private:
+  MCP342X sensor;
+};
+
 #endif

--- a/src/core/ExternalSensors.cpp
+++ b/src/core/ExternalSensors.cpp
@@ -103,6 +103,13 @@ void ExternalSensors::begin() {
           new ExternalSensor<SDS011>());
       sensors[i].exSensor = sds011.release();
       sensors[i].exSensor-> begin();
+    } else if ((sensors[i].reference) == "MCP342X_4-20mA") {
+      int16_t channel0, channel1, channel2, channel3;
+
+      std::unique_ptr<ExternalSensor<MCP342X>> analogI2C(
+          new ExternalSensor<MCP342X>(sensors[i].address));
+      sensors[i].exSensor = analogI2C.release();
+      sensors[i].exSensor->read(&channel0, &channel1, &channel2, &channel3);
     }
   }
 }
@@ -164,6 +171,18 @@ void ExternalSensors::read(JsonObject &root) {
           delay(200);
           root[sensors[i].kind0] = A; //PM10
           root[sensors[i].kind1] = B; //PM2.5
+        } else if (sensors[i].reference == "MCP342X_4-20mA") {
+          int16_t channel0, channel1, channel2, channel3;
+
+          sensors[i].exSensor->read(&channel0, &channel1, &channel2, &channel3);
+          root[sensors[i].kind0] = channel0;
+          root[sensors[i].kind1] = channel1;
+          root[sensors[i].kind2] = channel2;
+          root[sensors[i].kind3] = channel3;
+          DEBUG_VAR("MCP342X Channel 1 Output:",channel0);
+          DEBUG_VAR("MCP342X Channel 2 Output:",channel1);
+          DEBUG_VAR("MCP342X Channel 3 Output:",channel2);
+          DEBUG_VAR("MCP342X Channel 4 Output:",channel3);
         } else {
           root[sensors[i].type] = sensors[i].exSensor->read();
         }


### PR DESCRIPTION
This is only a first integration of [this](https://www.ereshop.com/shop/index.php?main_page=product_info&cPath=143&products_id=805&zenid=cdf233ca4f9d4cb4e317c3a524d34ae7) 4-20mA interface ([Datasheet](https://www.ereshop.com/shop/free/I2C-AI418S_SHEET.pdf)). The Interface worked perfect without hanging or wrong readings for a week and is allready integrated on CoolCave.
It returns the value as a **RAW 16 bit int**. the ADC is capable to take 18 bit readings but this never worked with the code provided...
Thus the integration is not finished, no calibration was done. I have to take a look at this later with the front and back team.. Please take a look on the Datasheet for maximum readings.
I will create the issues in the corresponding repository's as soon as the PR was merged. 
