### PR TITLE
Range Low and High for Actors accept floats

### DIFF
--- a/src/core/CoolBoardActuator.cpp
+++ b/src/core/CoolBoardActuator.cpp
@@ -128,12 +128,12 @@ bool CoolBoardActuator::config() {
   // parsing inverted key
   config.set<bool>(json, "inverted", this->inverted);
   // parsing low key
-  config.setArray<int>(json, "low", 0, this->rangeLow);
+  config.setArray<float>(json, "low", 0, this->rangeLow);
   config.setArray<unsigned long>(json, "low", 1, this->timeLow);
   config.setArray<uint8_t>(json, "low", 2, this->hourLow);
   config.setArray<uint8_t>(json, "low", 3, this->minuteLow);
   // parsing high key
-  config.setArray<int>(json, "high", 0, this->rangeHigh);
+  config.setArray<float>(json, "high", 0, this->rangeHigh);
   config.setArray<unsigned long>(json, "high", 1, this->timeHigh);
   config.setArray<uint8_t>(json, "high", 2, this->hourHigh);
   config.setArray<uint8_t>(json, "high", 3, this->minuteHigh);

--- a/src/core/CoolBoardActuator.h
+++ b/src/core/CoolBoardActuator.h
@@ -57,11 +57,11 @@ public:
   bool inverted = false;
   String primaryType = "";
   String secondaryType = "";
-  int rangeLow = 0;
+  float rangeLow = 0;
   unsigned long timeLow = 0;
   uint8_t hourLow = 0;
   uint8_t minuteLow = 0;
-  int rangeHigh = 0;
+  float rangeHigh = 0;
   unsigned long timeHigh = 0;
   uint8_t hourHigh = 0;
   uint8_t minuteHigh = 0;

--- a/src/core/Jetpack.cpp
+++ b/src/core/Jetpack.cpp
@@ -80,12 +80,12 @@ bool Jetpack::config() {
       // parsing inverted key
       config.set<bool>(act, "inverted", this->actuatorList[i].inverted);
       // parsing low key
-      config.setArray<int>(act, "low", 0, this->actuatorList[i].rangeLow);
+      config.setArray<float>(act, "low", 0, this->actuatorList[i].rangeLow);
       config.setArray<unsigned long>(act, "low", 1, this->actuatorList[i].timeLow);
       config.setArray<uint8_t>(act, "low", 2, this->actuatorList[i].hourLow);
       config.setArray<uint8_t>(act, "low", 3, this->actuatorList[i].minuteLow);
       // parsing high key
-      config.setArray<int>(act, "high", 0, this->actuatorList[i].rangeHigh);
+      config.setArray<float>(act, "high", 0, this->actuatorList[i].rangeHigh);
       config.setArray<unsigned long>(act, "high", 1, this->actuatorList[i].timeHigh);
       config.setArray<uint8_t>(act, "high", 2, this->actuatorList[i].hourHigh);
       config.setArray<uint8_t>(act, "high", 3, this->actuatorList[i].minuteHigh);


### PR DESCRIPTION
When I tried to control a pump pumping nutrients from a auxiliary reservoir to the main reservoir I saw that `floats` where not recognized and my `lowRange` and `highRange` where treated as `int`. 
not very handy to switch a pump when the EC goes lower than 0.5ms/cm.